### PR TITLE
Add Magnum Enforcer book series bonuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,6 @@
 
 ## V1.0.1 - Feb 2, 2022
 - Fixed HP and AP 44 ammo damage not being properly applied
+
+## V1.1.0 - Feb 8, 2022
+- Updated to apply bonuses from Magnum Enforcer series books 1, 3, 4, 7, and series completion bonus to Lever Action Rifle

--- a/PlaebadLeverAction44/Config/items.xml
+++ b/PlaebadLeverAction44/Config/items.xml
@@ -2,6 +2,8 @@
 
 	<!-- Modify lever action rifle to use 44 ammo -->
 	<set xpath="/items/item[@name='gunRifleT2LeverActionRifle']/property[@class='Action0']/property[@name='Magazine_items']/@value">ammo44MagnumBulletBall,ammo44MagnumBulletHP,ammo44MagnumBulletAP</set>
+	<!-- Add custom tag to the Lever Action Rifle to enable certain Magnum Enforcer perks -->
+	<set xpath="/items/item[@name='gunRifleT2LeverActionRifle']/property[@name='Tags']/@value">weapon,ranged,holdBreathAiming,reloadPenalty,gun,barrelAttachments,sideAttachments,smallTopAttachments,mediumTopAttachments,largeTopAttachments,stock,bottomAttachments,attPerception,perkDeadEye,attachmentsIncluded,canHaveCosmetic,rifle44</set>
 	<!-- Update item packs for level action rifle to include 44 ammo instead of 7.62 -->
 	<set xpath="/items/item[@name='LoadoutTier3Rifle']/property[@class='Action0']/property[@name='Create_item']/@value">ammo44MagnumBulletBall,gunRifleT2LeverActionRifle</set>
 	<set xpath="/items/item[@name='LoadoutTier4Rifle01']/property[@class='Action0']/property[@name='Create_item']/@value">ammo44MagnumBulletBall,gunRifleT2LeverActionRifle</set>
@@ -13,5 +15,16 @@
 	<set xpath="/items/item[@name='ammo44MagnumBulletAP']/effect_group[@name='ammo44MagnumBulletAP']/passive_effect[@name='EntityDamage']/@tags">perkGunslinger,revolver,ranged</set>
 	<!-- Adjust weapon damage to make it consistent with 44 handguns so it is not OP -->
 	<set xpath="/items/item[@name='gunRifleT2LeverActionRifle']/effect_group[@name='gunRifleT2LeverActionRifle']/passive_effect[@name='EntityDamage' and @operation='base_add']/@value">-2</set>
+	<!-- Add Magnum Enforcer series completion bonus (penetration) for Lever Action 44-->
+	<insertAfter xpath="/items/item[@name='ammo44MagnumBulletBall']/effect_group[@name='ammo44MagnumBulletBall']/passive_effect[@name='EntityPenetrationCount']">
+        <passive_effect name="EntityPenetrationCount" operation="base_set" value="1" tags="rifle44">
+			<requirement name="ProgressionLevel" progression_name="perkEnforcerComplete" operation="Equals" value="1"/>
+		</passive_effect>
+    </insertAfter>
+	<insertAfter xpath="/items/item[@name='ammo44MagnumBulletHP']/effect_group[@name='ammo44MagnumBulletHP']/passive_effect[@name='EntityPenetrationCount']">
+        <passive_effect name="EntityPenetrationCount" operation="base_set" value="1" tags="rifle44">
+			<requirement name="ProgressionLevel" progression_name="perkEnforcerComplete" operation="Equals" value="1"/>
+		</passive_effect>
+    </insertAfter>
 
 </PlaebadLeverAction44>

--- a/PlaebadLeverAction44/Config/progression.xml
+++ b/PlaebadLeverAction44/Config/progression.xml
@@ -1,0 +1,45 @@
+<PlaebadLeverAction44Progression>
+
+    <!-- Enable applicable Magnum Enforcer book perks for the Lever Action Rifle -->
+
+    <!-- Book 1: 10 pct more damage -->
+    <insertAfter xpath="/progression/perks/perk[@name='perkEnforcerDamage']/effect_group[1]">
+        <effect_group>
+				<passive_effect name="EntityDamage" operation="perc_add" level="1" value="0.1" tags="rifle44"/>
+		</effect_group>
+    </insertAfter>
+
+    <!-- Book 3: Last shot double damgae -->
+    <insertAfter xpath="/progression/perks/perk[@name='perkEnforcerPunks']/effect_group[1]">
+        <effect_group>
+			<requirement name="RoundsInMagazine" operation="LTE" value="0"/>
+				<passive_effect name="EntityDamage" operation="perc_add" level="1" value="1" tags="rifle44"/>
+		</effect_group>
+    </insertAfter>
+
+    <!-- Book 4: 5 pct barter bonus -->
+    <insertAfter xpath="/progression/perks/perk[@name='perkEnforcerIntimidation']/effect_group[1]">
+        <effect_group>
+			<requirement name="ItemHasTags" tags="rifle44"/>
+				<passive_effect name="BarteringBuying" operation="base_add" level="1" value="0.05"/>
+				<passive_effect name="BarteringSelling" operation="base_add" level="1" value="0.05"/>
+		</effect_group>
+    </insertAfter>
+
+    <!-- Book 7: 20 pct less stamina sprinting in combat -->
+    <insertAfter xpath="/progression/perks/perk[@name='perkEnforcerCriminalPursuit']/effect_group[1]">
+        <effect_group>
+			<requirement name="ItemHasTags" tags="rifle44"/>
+			<requirement name="ProgressionLevel" progression_name="perkEnforcerCriminalPursuit" operation="Equals" value="1"/>
+				<triggered_effect trigger="onCombatEntered" action="AddBuff" buff="buffEnforcerCriminalPursuit"/>
+		</effect_group>
+    </insertAfter>
+
+    <!-- Series completion bonus: Shot penetration and bulk unlock -->
+    <insertAfter xpath="/progression/perks/perk[@name='perkEnforcerComplete']/effect_group[1]">
+        <effect_group>
+			<passive_effect name="RecipeTagUnlocked" operation="base_set" level="1" value="1" tags="ammoBundle44MagnumBulletAP,ammoBundle44MagnumBulletHP,ammoBundle44MagnumBulletBall"/>
+		</effect_group>
+    </insertAfter>
+
+</PlaebadLeverAction44Progression>

--- a/PlaebadLeverAction44/ModInfo.xml
+++ b/PlaebadLeverAction44/ModInfo.xml
@@ -4,7 +4,7 @@
 		<Name value="LeverAction44" />
 		<Description value="Convert Lever Action rifle to use .44 ammo" />
 		<Author value="Plaebad" />
-		<Version value="1.0.1" />
+		<Version value="1.1.0" />
 		<Website value="" />
 	</ModInfo>
 </xml>

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ loaded into them and that ammo will not be returned to the player.
 
 You should end up with a path such as ```C:\Steam\steamapps\common\7 Days To Die\Mods\PlaebadLeverAction44```
 
+## Support
+
+Feedback and support requests can be submitted in Discord [https://discord.gg/PNp5k47zhB](https://discord.gg/PNp5k47zhB)
+in the plaebad-lever-action-44 channel.
+
 ## Disclaimer
 The mod author is not responsible for any damages or lost data that may occur from
 the use of this mod.


### PR DESCRIPTION
Updated to apply bonuses from the Magnum Enforcer series books 1, 3, 4, 7, and the series completion bonus.